### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sphinx
+sphinx==5.3.0
 piccolo_theme
-docutils==0.16.0
-sphinx_tabs
+docutils==0.17.1
+sphinx_tabs==3.4.0
 


### PR DESCRIPTION
Sphinx 6.0.0 recently released and dropped support for docutils 0.16.0. This combination of the packages seem to be compatible.